### PR TITLE
Specify suggested default models

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ pip install memary
 
 ## Demo
 **Notes:** memary currently assumes the local installation method and currently supports any models available through Ollama:
-- LLM running locally using Ollama **OR** `gpt-3.5-turbo`
-- Vision model running locally using Ollama **OR** `gpt-4-vision-preview`
+- LLM running locally using Ollama ((Llama 3 8B/40B as suggested defaults) **OR** `gpt-3.5-turbo`
+- Vision model running locally using Ollama (LLaVA as suggested default) **OR** `gpt-4-vision-preview`
 
 memary will default to the locally run models unless explicitly specified.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip install memary
 
 ## Demo
 **Notes:** memary currently assumes the local installation method and currently supports any models available through Ollama:
-- LLM running locally using Ollama ((Llama 3 8B/40B as suggested defaults) **OR** `gpt-3.5-turbo`
+- LLM running locally using Ollama (Llama 3 8B/40B as suggested defaults) **OR** `gpt-3.5-turbo`
 - Vision model running locally using Ollama (LLaVA as suggested default) **OR** `gpt-4-vision-preview`
 
 memary will default to the locally run models unless explicitly specified.


### PR DESCRIPTION
Specify Llama 3 8B/40B as suggested default language model and LLaVA as suggested default vision model 

These models were used for building/testing